### PR TITLE
fix: use loc.source instead of content to allow tsconfig strict options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ class VueTsJestTransformer extends TsJestTransformer implements Transformer {
     if (descriptor.script || descriptor.scriptSetup) {
       scriptSetupResult = compileScript(descriptor)
       bindings = scriptSetupResult.bindings
-      output = super.process(scriptSetupResult.content, `${filePath}.ts`, jestConfig, transformOptions)
+      output = super.process(scriptSetupResult.loc.source, `${filePath}.ts`, jestConfig, transformOptions)
       const template = compileTemplate({
         filename: descriptor.filename,
         source: descriptor.template!.content,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "CommonJS",
     "outDir": "dist",
     "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "importsNotUsedAsValues": "remove",


### PR DESCRIPTION
Use `scriptSetupResult.loc.source` will only pass `ts` content to `ts-jest`. This allows users to use strict options like `noUnusedLocals` or `noUnusedParameters`.

IMO, using `scriptSetupResult.loc.source` is more correct for code content for `ts-jest` to deal with.